### PR TITLE
feat: dailyJS upgrade 0.83.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@auth/prisma-adapter": "^2.7.4",
-        "@daily-co/daily-js": "^0.74.0",
+        "@daily-co/daily-js": "^0.83.1",
         "@daily-co/daily-react": "^0.22.0",
         "@fullcalendar/core": "^6.1.17",
         "@fullcalendar/daygrid": "^6.1.17",
@@ -194,9 +194,9 @@
       }
     },
     "node_modules/@daily-co/daily-js": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@daily-co/daily-js/-/daily-js-0.74.0.tgz",
-      "integrity": "sha512-wyZzt+sH7yh5Cg3DQeoZ1Yen8+bbai0/Zq8JZzklqELrpjiFuu34e3qwjwt79cx7T9eukbZbK6gtk3cmCBW3iw==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/@daily-co/daily-js/-/daily-js-0.83.1.tgz",
+      "integrity": "sha512-KXA3zrSnNPZONwhip4TI6ayD3huumI1QBD/xPAjFArvHuFFB7t0QTOS2oxH1bXvdOBJ6XnY08vdlJslTVi2/2w==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@sentry/browser": "^8.33.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.7.4",
-    "@daily-co/daily-js": "^0.74.0",
+    "@daily-co/daily-js": "^0.83.1",
     "@daily-co/daily-react": "^0.22.0",
     "@fullcalendar/core": "^6.1.17",
     "@fullcalendar/daygrid": "^6.1.17",


### PR DESCRIPTION
Upgraded the daily-JS pluging to the latest version.  The upcoming version of Chrome introduces a breaking change in how video and audio tracks are managed, preventing cameras from sending video in some cases